### PR TITLE
Google and Apple Sign In (buried)

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		D35673C62D3E91BD00E4E926 /* MainSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673C52D3E91B900E4E926 /* MainSceneDelegate.swift */; };
 		D35673C82D3EBFBA00E4E926 /* NowPlayingUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673C72D3EBFB000E4E926 /* NowPlayingUpdater.swift */; };
 		D35673CB2D3EE5E900E4E926 /* Secrets-Development.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D35673CA2D3EE5E100E4E926 /* Secrets-Development.xcconfig */; };
+		D3A2761E2D43C747006055AF /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = D3A2761D2D43C747006055AF /* GoogleSignIn */; };
+		D3A276202D43C747006055AF /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = D3A2761F2D43C747006055AF /* GoogleSignInSwift */; };
 		D3B662682D3F58E700975D2F /* FRadioPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = D3B662672D3F58E700975D2F /* FRadioPlayer */; };
 		D3B6626A2D40103C00975D2F /* SignInPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B662692D40103800975D2F /* SignInPage.swift */; };
 		D3B6626D2D4016C200975D2F /* NavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B6626C2D4016BF00975D2F /* NavigationCoordinator.swift */; };
@@ -149,9 +151,11 @@
 				D3CE19032D3C825C0091B888 /* PlayolaPlayer in Frameworks */,
 				D35673B72D3DC6EC00E4E926 /* Mixpanel in Frameworks */,
 				D31C43D42D3C783B0021AAE4 /* PlayolaPlayer in Frameworks */,
+				D3A276202D43C747006055AF /* GoogleSignInSwift in Frameworks */,
 				D3B662702D40352500975D2F /* Alamofire in Frameworks */,
 				D3536A302BFA5523006942D6 /* ComposableArchitecture in Frameworks */,
 				D3B662682D3F58E700975D2F /* FRadioPlayer in Frameworks */,
+				D3A2761E2D43C747006055AF /* GoogleSignIn in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -405,6 +409,8 @@
 				D35673B62D3DC6EC00E4E926 /* Mixpanel */,
 				D3B662672D3F58E700975D2F /* FRadioPlayer */,
 				D3B6626F2D40352500975D2F /* Alamofire */,
+				D3A2761D2D43C747006055AF /* GoogleSignIn */,
+				D3A2761F2D43C747006055AF /* GoogleSignInSwift */,
 			);
 			productName = PlayolaRadio;
 			productReference = D3536A012BFA4F49006942D6 /* PlayolaRadio.app */;
@@ -462,6 +468,7 @@
 				D35673B52D3DC6EC00E4E926 /* XCRemoteSwiftPackageReference "mixpanel-swift" */,
 				D3B662662D3F58E700975D2F /* XCRemoteSwiftPackageReference "FRadioPlayer" */,
 				D3B6626E2D40352500975D2F /* XCRemoteSwiftPackageReference "Alamofire" */,
+				D3A2761C2D43C747006055AF /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
 			);
 			productRefGroup = D3536A022BFA4F49006942D6 /* Products */;
 			projectDirPath = "";
@@ -969,6 +976,14 @@
 				kind = branch;
 			};
 		};
+		D3A2761C2D43C747006055AF /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/google/GoogleSignIn-iOS";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.0.0;
+			};
+		};
 		D3B662662D3F58E700975D2F /* XCRemoteSwiftPackageReference "FRadioPlayer" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/fethica/FRadioPlayer";
@@ -1009,6 +1024,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D35673B52D3DC6EC00E4E926 /* XCRemoteSwiftPackageReference "mixpanel-swift" */;
 			productName = Mixpanel;
+		};
+		D3A2761D2D43C747006055AF /* GoogleSignIn */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D3A2761C2D43C747006055AF /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
+			productName = GoogleSignIn;
+		};
+		D3A2761F2D43C747006055AF /* GoogleSignInSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D3A2761C2D43C747006055AF /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
+			productName = GoogleSignInSwift;
 		};
 		D3B662672D3F58E700975D2F /* FRadioPlayer */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		D35673CB2D3EE5E900E4E926 /* Secrets-Development.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D35673CA2D3EE5E100E4E926 /* Secrets-Development.xcconfig */; };
 		D3A2761E2D43C747006055AF /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = D3A2761D2D43C747006055AF /* GoogleSignIn */; };
 		D3A276202D43C747006055AF /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = D3A2761F2D43C747006055AF /* GoogleSignInSwift */; };
+		D3A276692D49628C006055AF /* UIApplication+keyWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A276682D496282006055AF /* UIApplication+keyWindow.swift */; };
 		D3B662682D3F58E700975D2F /* FRadioPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = D3B662672D3F58E700975D2F /* FRadioPlayer */; };
 		D3B6626A2D40103C00975D2F /* SignInPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B662692D40103800975D2F /* SignInPage.swift */; };
 		D3B6626D2D4016C200975D2F /* NavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B6626C2D4016BF00975D2F /* NavigationCoordinator.swift */; };
@@ -133,6 +134,7 @@
 		D35673C52D3E91B900E4E926 /* MainSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSceneDelegate.swift; sourceTree = "<group>"; };
 		D35673C72D3EBFB000E4E926 /* NowPlayingUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingUpdater.swift; sourceTree = "<group>"; };
 		D35673CA2D3EE5E100E4E926 /* Secrets-Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Secrets-Development.xcconfig"; sourceTree = "<group>"; };
+		D3A276682D496282006055AF /* UIApplication+keyWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+keyWindow.swift"; sourceTree = "<group>"; };
 		D3B662692D40103800975D2F /* SignInPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInPage.swift; sourceTree = "<group>"; };
 		D3B6626C2D4016BF00975D2F /* NavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinator.swift; sourceTree = "<group>"; };
 		D3B662712D41618500975D2F /* AppleSignInInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInInfo.swift; sourceTree = "<group>"; };
@@ -337,6 +339,7 @@
 		D3536A392BFA6520006942D6 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				D3A276682D496282006055AF /* UIApplication+keyWindow.swift */,
 				D35673C22D3E871800E4E926 /* CPListItem+InitWithRemoteUrl.swift */,
 				D3137DD32D3AC9B40070033A /* EnumTypeEquatableProtocol.swift */,
 				D3536A362BFA6520006942D6 /* Bundle+Misc.swift */,
@@ -534,6 +537,7 @@
 				D3B6626D2D4016C200975D2F /* NavigationCoordinator.swift in Sources */,
 				D3137DD42D3AC9BE0070033A /* EnumTypeEquatableProtocol.swift in Sources */,
 				D339E5632BFD0FD800B9E35B /* AirplayButton.swift in Sources */,
+				D3A276692D49628C006055AF /* UIApplication+keyWindow.swift in Sources */,
 				D35673C82D3EBFBA00E4E926 /* NowPlayingUpdater.swift in Sources */,
 				D3536A3A2BFA6520006942D6 /* Bundle+Misc.swift in Sources */,
 				D3CE19052D3CA6180091B888 /* SharedUserDefaults.swift in Sources */,

--- a/PlayolaRadio/Config/Config.swift
+++ b/PlayolaRadio/Config/Config.swift
@@ -17,7 +17,7 @@ class Config: ObservableObject {
   var baseUrl: String {
     switch environment {
     case .local:
-      return "https://localhost:10020"
+      return "http://localhost:10020"
     case .development, .production:
       return "https://admin-api.playola.fm"
     }

--- a/PlayolaRadio/Extensions/UIApplication+keyWindow.swift
+++ b/PlayolaRadio/Extensions/UIApplication+keyWindow.swift
@@ -1,0 +1,37 @@
+//
+//  UIApplication+keyWindow.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 1/28/25.
+//
+import Foundation
+import SwiftUI
+
+extension UIApplication {
+  public var keyWindow: UIWindow? {
+    return Self
+      .shared
+      .connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .flatMap { $0.windows }
+      .last { $0.isKeyWindow }
+  }
+
+  public var keyWindowPresentedController: UIViewController? {
+    var viewController = self.keyWindow?.rootViewController
+
+    if let presentedController = viewController as? UITabBarController {
+      viewController = presentedController.selectedViewController
+    }
+
+    // Go deeper to find the last presented `UIViewController`
+    while let presentedController = viewController?.presentedViewController {
+      if let presentedController = presentedController as? UITabBarController {
+        viewController = presentedController.selectedViewController
+      } else {
+        viewController = presentedController
+      }
+    }
+    return viewController
+  }
+}

--- a/PlayolaRadio/Info.plist
+++ b/PlayolaRadio/Info.plist
@@ -6,8 +6,25 @@
 	<array>
 		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	</array>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string></string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.googleusercontent.apps.126767027087-5ediuop75anadcrbqsugutvet366i9mu</string>
+			</array>
+		</dict>
+	</array>
 	<key>DEV_ENVIRONMENT</key>
 	<string>$(DEV_ENVIRONMENT)</string>
+	<key>GIDClientID</key>
+	<string>126767027087-5ediuop75anadcrbqsugutvet366i9mu.apps.googleusercontent.com</string>
+	<key>GIDServerClientID</key>
+	<string>126767027087-2gp2aiprh5564qsstjmp6uuqcdg64hev.apps.googleusercontent.com</string>
 	<key>HEAP_APP_ID</key>
 	<string>$(HEAP_APP_ID)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -7,6 +7,8 @@
 
 import ComposableArchitecture
 import SwiftUI
+import GoogleSignIn
+import GoogleSignInSwift
 
 @main
 struct PlayolaRadioApp: App {
@@ -20,6 +22,14 @@ struct PlayolaRadioApp: App {
         EmptyView()
       } else {
         AppView()
+          .onOpenURL { url in
+            GIDSignIn.sharedInstance.handle(url)
+          }
+          .onAppear {
+            GIDSignIn.sharedInstance.restorePreviousSignIn { user, error in
+              // Check if `user` exists; otherwise, do something with `error`
+            }
+          }
       }
     }
   }

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPage.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPage.swift
@@ -51,6 +51,7 @@ class SignInPageModel: ViewModel {
                            authCode: authCode,
                            displayName: appleIDCredential.fullName?.formatted())
     case .failure(let error):
+      print(error)
       break
     }
   }
@@ -68,11 +69,11 @@ class SignInPageModel: ViewModel {
 
       signInResult.user.refreshTokensIfNeeded { user, error in
         guard error == nil else { return }
-        guard let authCode = signInResult.serverAuthCode else {
+        guard let serverAuthCode = signInResult.serverAuthCode else {
           print("Error signing into Google -- no serverAuthCode on signInResult.")
           return
         }
-        API().signInViaGoogle(code: signInResult.serverAuthCode!)
+        API().signInViaGoogle(code: serverAuthCode)
       }
     }
   }

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
@@ -29,5 +29,6 @@ struct SignInPageTests {
     // @Test("Provides the results to the API")
   }
 
+  // @Suite("SignInWithGoogle")
   // @Test("LogOutButtonTapped()")
 }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -144,8 +144,7 @@ struct StationListPage: View {
       switch item {
       case .about(let aboutModel):
         NavigationStack {
-//          AboutPage(model: aboutModel)
-          SignInPage(model: SignInPageModel())
+          AboutPage(model: aboutModel)
             .toolbar {
                     ToolbarItem(placement: .confirmationAction) {
                       Button(action: { model.dismissButtonInSheetTapped()  }) {

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -144,7 +144,8 @@ struct StationListPage: View {
       switch item {
       case .about(let aboutModel):
         NavigationStack {
-          AboutPage(model: aboutModel)
+//          AboutPage(model: aboutModel)
+          SignInPage(model: SignInPageModel())
             .toolbar {
                     ToolbarItem(placement: .confirmationAction) {
                       Button(action: { model.dismissButtonInSheetTapped()  }) {


### PR DESCRIPTION
This pull request introduces significant changes to the `PlayolaRadio` project, primarily focused on integrating Google Sign-In functionality and updating configurations. Below is a summary of the most important changes:

### Integration of Google Sign-In:

* Added Google Sign-In framework references and configuration to `PlayolaRadio.xcodeproj`:
  - Added `GoogleSignIn` and `GoogleSignInSwift` to the project frameworks. [[1]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R60-R62) [[2]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R156-R160) [[3]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R415-R416)
  - Included `UIApplication+keyWindow.swift` for handling key window operations. [[1]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R137) [[2]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R342) [[3]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R540)
  - Configured `XCRemoteSwiftPackageReference` for `GoogleSignIn-iOS`. [[1]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R474) [[2]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R983-R990) [[3]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R1032-R1041)

* Updated `Info.plist` to include Google Sign-In related keys:
  - Added `CFBundleURLTypes`, `GIDClientID`, and `GIDServerClientID`.

### API and Authentication Updates:

* Added new methods in `API.swift` for handling Google Sign-In and Apple credentials revocation:
  - Implemented `revokeAppleCredentials` and `signInViaGoogle` methods.

* Created `AuthService` class to manage authentication state and handle Apple ID credential revocation notifications:
  - Added `signOut` and `clearAppleUser` methods.

### UI and User Experience Enhancements:

* Updated `SignInPage` to include a Google Sign-In button and handle sign-in logic:
  - Added `signInWithGoogleButtonTapped` method and integrated `GoogleSignInButton` into the UI. [[1]](diffhunk://#diff-04bf419bf2b87ad3ac98ec2b541fec13eb63b07db61a9e9cccea8b188e0e1e4cR54-R83) [[2]](diffhunk://#diff-04bf419bf2b87ad3ac98ec2b541fec13eb63b07db61a9e9cccea8b188e0e1e4cR115-R126)

* Modified `PlayolaRadioApp` to handle Google Sign-In URL callbacks and restore previous sign-in state:
  - Added `onOpenURL` and `onAppear` handlers for `GIDSignIn`.

### Miscellaneous Changes:

* Changed the `baseUrl` for the local environment in `Config.swift` from `https` to `http`.

These changes collectively enhance the authentication capabilities of the `PlayolaRadio` app by integrating Google Sign-In, improving user experience, and ensuring proper handling of authentication states.